### PR TITLE
Fix the vignette ChromBand

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Category
 Title: Category Analysis
-Version: 2.53.0
+Version: 2.53.1
 Authors@R: c(
     person("Robert", "Gentleman", role="aut"),
     person("Seth", "Falcon", role="ctb"),
@@ -15,7 +15,7 @@ Depends: methods, stats4, BiocGenerics, AnnotationDbi, Biobase,
          Matrix
 Imports: utils, stats, graph, RBGL, GSEABase, genefilter, annotate, DBI 
 Suggests: EBarrays, ALL, Rgraphviz, RColorBrewer, xtable (>= 1.4-6),
-         hgu95av2.db, KEGG.db, SNPchip, geneplotter, limma, lattice,
+         hgu95av2.db, KEGG.db, karyoploteR, geneplotter, limma, lattice,
          RUnit, org.Sc.sgd.db, GOstats, GO.db
 LazyLoad: Yes
 Collate: AllClasses.R AllGenerics.R categoryToEntrezBuilder-methods.R

--- a/vignettes/ChromBand.Rnw
+++ b/vignettes/ChromBand.Rnw
@@ -103,7 +103,8 @@ library("ALL")
 library("hgu95av2.db")
 library("annotate")
 library("genefilter")
-library("SNPchip")
+##library("SNPchip")
+library("karyoploteR")
 library("geneplotter")
 library("limma")
 library("lattice")
@@ -117,21 +118,22 @@ library("graph")
 \begin{figure}[tb]
 \begin{center}
 %
-<<chr12ideogram, fig=TRUE, include=FALSE, prefix=FALSE, echo=FALSE, width=9, height=1.75>>=
+<<chr12ideogram, fig=TRUE, include=FALSE, prefix=FALSE, echo=FALSE, width=9, height=3>>=
 build <- "hg19" ## or hg18
-cyt2 <- getCytoband(build=build)
-cyt2$gieStain <- "foo"
-c12p12_idx <- intersect(grep("^q21", cyt2$name),
-                        which(cyt2$chrom == "12"))
-cyt2[c12p12_idx, "gieStain"] <- rep(c("gpos50", "gpos75"),
-                                    length=length(c12p12_idx))
-
-
-plotCytoband2(chromosome="12", build=build, cytoband=cyt2, outer=FALSE,  ## From SNPchip
-    cex.axis=0.6, main="Human chromosome 12")
-plotCytoband2(chromosome="12", build=build, cytoband=cyt2, outer=FALSE,
-              cex.axis=0.6,
-              main="Human chromosome 12")
+kp <- plotKaryotype(genome=build, chromosomes="chr12", main="Human chromosome 12")
+## cyt2 <- getCytoband(build=build)
+## cyt2$gieStain <- "foo"
+## c12p12_idx <- intersect(grep("^q21", cyt2$name),
+##                         which(cyt2$chrom == "12"))
+## cyt2[c12p12_idx, "gieStain"] <- rep(c("gpos50", "gpos75"),
+##                                     length=length(c12p12_idx))
+##
+##
+## plotCytoband2(chromosome="12", build=build, cytoband=cyt2, outer=FALSE,  ## From SNPchip
+##     cex.axis=0.6, main="Human chromosome 12")
+## plotCytoband2(chromosome="12", build=build, cytoband=cyt2, outer=FALSE,
+##               cex.axis=0.6,
+##               main="Human chromosome 12")
 @ 
 \end{center}
 \includegraphics[width=.98\textwidth]{chr12ideogram}


### PR DESCRIPTION
hi,

the vignette ChromBand currently breaks because it uses a package SNPchip to just plot the ideogram of chromosome 12. This packages has been deprecated in release 3.10 and removed in current development 3.11. This pull request replaces SNPchip by [karyoploteR](https://bioconductor.org/packages/karyoploteR) to just make that plot.